### PR TITLE
Handling NULL values for group day

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,7 +199,7 @@ document.addEventListener('alpine:init', () => {
 		filterGroups() {
 			this.groups = this.allFormattedGroups.filter(group => {
 				const clusterMatched = group.cluster == null && this.cluster.length ? false : (!this.cluster.length || group.cluster == this.cluster);
-				const dayMatched = !this.day.length || group.day.format('dddd') == this.day;
+				const dayMatched = group.day == null || (!this.day.length || group.day.format('dddd') == this.day);
 				const tagMatched = !this.tag.length || group.tags.map(tag => tag.name).includes(this.tag);
 				const searchMatched = !this.search.length || group.name.toLowerCase().includes(this.search.toLowerCase());
 				const siteMatched = group.site == null ? true : (!this.site.length || group.site == this.site);


### PR DESCRIPTION
A group's day can be a NULL value when "Various Days" is selected as the option within ChurchSuite. Previously, we weren't handling this scenario, which resulted in a JS error. This updates the logic so that, when filtering groups, we consider a group to match the day search filter if the group meets on "Various Days"/NULL or we have an actual match.